### PR TITLE
Add Clerk user domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10951,6 +10951,11 @@ virtueeldomein.nl
 // Submitted by Quentin Adam <noc@clever-cloud.com>
 cleverapps.io
 
+// Clerk : https://www.clerk.dev
+// Submitted by Colin Sidoti <colin@clerk.dev>
+*.lcl.dev
+*.stg.dev
+
 // Cloud66 : https://www.cloud66.com/
 // Submitted by Khash Sajadi <khash@cloud66.com>
 c66.me


### PR DESCRIPTION
* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [ ] DNS verification via dig
* [ ] Run Syntax Checker (make test)

Description of Organization
====

Clerk provides user authentication as a service to developers. 

Organization Website: https://www.clerk.dev

I am the founder and CEO of Clerk.

Reason for PSL Inclusion
====

We should be in the PSL for both cookie security and to mitigate Let's Encrypt issuance restrictions.

Our service relies on us sharing a domain with our user so we can set cookies on their behalf.  For example, if their app is hosted on `www.example.com`, we will host our service on `accounts.example.com`.  With this structure, `accounts.example.com` can set a cookie with `Domain=example.com;` and `www.example.com` will be able to read it.

To mirror this behavior in development and staging environments, we provide subdomains on `*.lcl.dev` and `*.stg.dev` respectively.  As an example, if a user is running a Widget Factory we may tunnel their localhost to `www.widget-factory.a12.lcl.dev`, and we will host our service at `accounts.widget-factory.a12.lcl.dev`.  The token `a12` in this case is simply an extra, random level of namespacing.  It allows multiple Widget Factory team members to use the same 2 left-most parts while still keeping cookies separate.  This is also why we have a wildcard in our PSL request.

This pull request ensures that our users will not be able to set cookies on `lcl.dev` nor `*.lcl.dev`, and will keep their Cookie-Writing privileges properly scoped to the left-most parts of the domains we issue.  It will also allow us to issue up to 50 Let's Encrypt certificates for each development and staging environment (in the example above, `a12.lcl.dev` would be treated as a public suffix and `widget-factory.a12.com` would be treated as a domain with an independent limit).


DNS Verification via dig
=======

<!--
For each domain you'd like to add to the list please create
a DNS verification record pointing to your pull request.

For example, if you'd like to add example.com and example.net
you would need to provide the following verifications:

```
dig +short TXT _psl.example.com
"https://github.com/publicsuffix/list/pull/XXXX"
```

```
dig +short TXT _psl.example.net
"https://github.com/publicsuffix/list/pull/XXXX"
```

Note that XXXX is replaced with the number of your pull request.
-->

make test
=========

<!--
Please verify that you followed the correct syntax and nothing broke

git clone https://github.com/publicsuffix/list.git
cd list
make test

Simply let us know that you ran the test
-->
